### PR TITLE
Feat: collector

### DIFF
--- a/scripts/deploy_collector.sh
+++ b/scripts/deploy_collector.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source .env
+
+echo "Deploying Collector..."
+
+echo "Deploy args:
+FeeModule: $FEE_MODULE
+Admin: $ADMIN
+"
+
+# OUTPUT="$(forge script DeployCollector \
+#     --private-key $PK \
+#     --rpc-url $RPC_URL \
+#     --json \
+#     --broadcast \
+#     -s "run(address,address)" $ADMIN $FEE_MODULE)"
+OUTPUT="$(forge script DeployCollector \
+    --private-key $PK \
+    --rpc-url $RPC_URL \
+    --json \
+    -s "run(address,address)" $ADMIN $FEE_MODULE)"
+
+COLLECTOR=$(echo "$OUTPUT" | grep "{" | jq -r .returns.collector.value)
+echo "Collector deployed at address: $COLLECTOR"
+
+echo "Complete!"

--- a/scripts/deploy_collector.sh
+++ b/scripts/deploy_collector.sh
@@ -9,16 +9,11 @@ FeeModule: $FEE_MODULE
 Admin: $ADMIN
 "
 
-# OUTPUT="$(forge script DeployCollector \
-#     --private-key $PK \
-#     --rpc-url $RPC_URL \
-#     --json \
-#     --broadcast \
-#     -s "run(address,address)" $ADMIN $FEE_MODULE)"
 OUTPUT="$(forge script DeployCollector \
     --private-key $PK \
     --rpc-url $RPC_URL \
     --json \
+    --broadcast \
     -s "run(address,address)" $ADMIN $FEE_MODULE)"
 
 COLLECTOR=$(echo "$OUTPUT" | grep "{" | jq -r .returns.collector.value)

--- a/src/Collector.sol
+++ b/src/Collector.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Auth } from "./mixins/Auth.sol";
+import { IFeeModule } from "./interfaces/IFeeModule.sol";
+
+struct WithdrawOpts {
+    uint256 tokenId;
+    address to;
+    uint256 amount;
+}
+
+contract Collector is Auth {
+    IFeeModule public immutable feeModule;
+
+    constructor(address _feeModule) {
+        feeModule = IFeeModule(_feeModule);
+    }
+
+    function withdrawFees(WithdrawOpts[] calldata opts) external onlyAdmin {
+        for (uint256 i = 0; i < opts.length; ++i) {
+            WithdrawOpts memory opt = opts[i];
+            feeModule.withdrawFees(opt.to, opt.tokenId, opt.amount);
+        }
+    }
+}

--- a/src/scripts/deploy/DeployCollector.s.sol
+++ b/src/scripts/deploy/DeployCollector.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { Script } from "lib/forge-std/src/Script.sol";
+import { Collector } from "src/Collector.sol";
+
+/// @title DeployCollector
+/// @notice Script to deploy the Collector
+/// @author Polymarket
+contract DeployCollector is Script {
+    /// @notice Deploys the Collector
+    /// @param admin    - The admin
+    /// @param feeModule - The fee module address
+    function run(address admin, address feeModule) public returns (address collector) {
+        vm.startBroadcast();
+
+        Collector col = new Collector(feeModule);
+
+        // Add admin auth to the Admin address
+        col.addAdmin(admin);
+
+        // revoke deployer's auth
+        col.renounceAdmin();
+
+        collector = address(col);
+
+        vm.stopBroadcast();
+
+        if (!_verifyStatePostDeployment(admin, feeModule, collector)) revert("state verification post deployment failed");
+    }
+
+    function _verifyStatePostDeployment(address admin, address feeModule, address collector)
+        internal
+        view
+        returns (bool)
+    {
+        Collector col = Collector(collector);
+
+        if (col.isAdmin(msg.sender)) revert("Deployer admin not renounced");
+        if (!col.isAdmin(admin)) revert("Collector admin not set");
+        if (address(col.feeModule()) != feeModule) revert("Unexpected feeModule set on the Collector");
+
+        return true;
+    }
+}

--- a/src/test/Collector.t.sol
+++ b/src/test/Collector.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { CollectorTestHelper } from "./dev/CollectorTestHelper.sol";
+
+import { WithdrawOpts } from "src/Collector.sol";
+
+contract CollectorTest is CollectorTestHelper {
+    function testSetup() public {
+        assertEq(address(feeModule), address(collector.feeModule()));
+    }
+
+    function testWithdrawFees(uint64 _amount) public {
+        vm.assume(_amount > 0);
+        uint256 amount = uint256(_amount);
+        WithdrawOpts[] memory opts = new WithdrawOpts[](3);
+        opts[0] = _createWithdrawOpts(0, brian, amount);
+        opts[1] = _createWithdrawOpts(yes, brian, amount);
+        opts[2] = _createWithdrawOpts(no, brian, amount);
+
+        // deal tokens to the fee module
+        _mintTokens(address(feeModule), amount);
+
+        vm.prank(admin);
+        collector.withdrawFees(opts);
+
+        // Assert balances
+        assertEq(amount, balanceOf(address(usdc), brian));
+        assertEq(amount, balanceOf1155(address(ctf), brian, yes));
+        assertEq(amount, balanceOf1155(address(ctf),brian ,no));
+    }
+}

--- a/src/test/Collector.t.sol
+++ b/src/test/Collector.t.sol
@@ -27,6 +27,6 @@ contract CollectorTest is CollectorTestHelper {
         // Assert balances
         assertEq(amount, balanceOf(address(usdc), brian));
         assertEq(amount, balanceOf1155(address(ctf), brian, yes));
-        assertEq(amount, balanceOf1155(address(ctf),brian ,no));
+        assertEq(amount, balanceOf1155(address(ctf), brian, no));
     }
 }

--- a/src/test/dev/CollectorTestHelper.sol
+++ b/src/test/dev/CollectorTestHelper.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+import { console2 as console } from "lib/forge-std/src/Test.sol";
+
+import { ERC1155 } from "lib/solmate/src/tokens/ERC1155.sol";
+
+import { IFeeModule } from "../../interfaces/IFeeModule.sol";
+import { IConditionalTokens } from "../../interfaces/IConditionalTokens.sol";
+
+import { FeeModuleTestHelper } from "./FeeModuleTestHelper.sol";
+
+import { WithdrawOpts, Collector } from "src/Collector.sol";
+
+contract CollectorTestHelper is FeeModuleTestHelper {
+    Collector public collector;
+
+    function setUp() public override {
+        FeeModuleTestHelper.setUp();
+        collector = new Collector(address(feeModule));
+
+        // Authorizations
+        vm.prank(admin);
+        feeModule.addAdmin(address(collector));
+
+        collector.addAdmin(admin);
+    }
+
+    function _mintTokens(address to, uint256 amount) internal {
+        // deal USDC
+        deal(address(usdc), to, amount);
+
+        // deal CTF Tokens by splitting
+        _mintOutcomeTokens(to, amount);
+    }
+
+    function _mintOutcomeTokens(address to, uint256 amount) internal {
+        vm.startPrank(admin);
+        deal(address(usdc), admin, amount);
+
+        uint256[] memory partition = new uint256[](2);
+        partition[0] = 1;
+        partition[1] = 2;
+
+        approve(address(usdc), address(ctf), amount);
+
+        IConditionalTokens(ctf).splitPosition(address(usdc), bytes32(0), conditionId, partition, amount);
+
+        ERC1155(ctf).safeTransferFrom(admin, to, yes, amount, hex"");
+        ERC1155(ctf).safeTransferFrom(admin, to, no, amount, hex"");
+        vm.stopPrank();
+    }
+
+    function _createWithdrawOpts(uint256 tokenId, address to, uint256 amount)
+        internal
+        pure
+        returns (WithdrawOpts memory)
+    {
+        return WithdrawOpts({ tokenId: tokenId, to: to, amount: amount });
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new on-chain fee collector plus deployment tooling and tests.
> 
> - Adds `Collector` contract with admin-only `withdrawFees(WithdrawOpts[])` that forwards withdrawals to `IFeeModule`
> - New Forge deploy script `src/scripts/deploy/DeployCollector.s.sol` creates `Collector`, assigns admin, renounces deployer, and verifies state
> - Adds shell wrapper `scripts/deploy_collector.sh` to broadcast deployment via `forge script` and output the deployed address
> - Adds tests `src/test/Collector.t.sol` and helpers to validate setup and successful multi-asset withdrawals
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a434e6e4319db33db7fa7a5f16dd1113f968fca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->